### PR TITLE
Add binutils paths and rpaths

### DIFF
--- a/src/configure
+++ b/src/configure
@@ -217,6 +217,8 @@ if [ $vprof_flag == 1 ]; then
     echo -n testing for binutils config.h...
     if [ -f $binutils_path/include/config.h ]; then
       echo found
+    elif [ -f $binutils_path/include/extra/config.h ]; then
+      echo found
     else
       echo binutils config.h not found ... check your binutils path ... exiting
       exit

--- a/src/makefile.in
+++ b/src/makefile.in
@@ -6,7 +6,7 @@
 ifeq ($(VPROF),-DVPROF)
   VPROF_STATIC_OBJ  = vprof_static.o
   VPROF_DYNAMIC_OBJ = vprof_bfd.o
-  BFD_LIB   = -L BINUTILS_INSTALL_PATH/lib -lbfd  -L BINUTILS_INSTALL_PATH/lib64 -liberty -lz  
+  BFD_LIB   = -Wl,-rpath=BINUTILS_INSTALL_PATH/lib64 -Wl,-rpath=BINUTILS_INSTALL_PATH/lib -L BINUTILS_INSTALL_PATH/lib -L BINUTILS_INSTALL_PATH/lib64 -lbfd -liberty -lz  
 else
   VPROF_OBJ = 
   BFD_LIB   = 
@@ -91,8 +91,8 @@ hpm.o : hpm.c counters.h
 	$(CC) -c $(CFLAGS) $(UNCORE) -DUSE_MPI $(PAPI_INC) hpm.c -o $@
 
 vprof_static.o : ../vprof/vprof_static.c
-	$(CC) -c $(CFLAGS) -I BINUTILS_INSTALL_PATH/include ../vprof/vprof_static.c -o $@
-	
+	$(CC) -c $(CFLAGS) -I BINUTILS_INSTALL_PATH/include -I BINUTILS_INSTALL_PATH/include/extra ../vprof/vprof_static.c -o $@
+
 vprof_bfd.o : ../vprof/vprof_bfd.c
-	$(CC) -c $(CFLAGS) -I BINUTILS_INSTALL_PATH/include ../vprof/vprof_bfd.c -o $@
+	$(CC) -c $(CFLAGS) -I BINUTILS_INSTALL_PATH/include -I BINUTILS_INSTALL_PATH/include/extra ../vprof/vprof_bfd.c -o $@
 


### PR DESCRIPTION
Please let me know if you think this PR is valid.

I built binutils with spack, and found I needed to change the include paths, to include "extras" and it was convenient to use rpath to keep libbfd loadable if I switch spack environments after compiling the .so modules.